### PR TITLE
Add LFMD holds for LFMN_* positions

### DIFF
--- a/config/predefined_holds.json
+++ b/config/predefined_holds.json
@@ -698,13 +698,25 @@
       "upperfl": 170,
       "lowerfl": 130
     },
+    "INLOV": {
+      "upperfl": 140,
+      "lowerfl": 40
+    },
     "MUS": {
       "upperfl": 140,
       "lowerfl": 80
     },
+    "MD414": {
+      "upperfl": 20,
+      "lowerfl": 15
+    },
     "NERAS": {
       "upperfl": 140,
       "lowerfl": 70
+    },
+    "NEKIP": {
+      "upperfl": 110,
+      "lowerfl": 60
     }
   },
   "LFMP_": {


### PR DESCRIPTION
Add LFMD predefined holds for `LFMN_APP`, `LFMN_E_APP`, `LFMN_F_APP` positions in order to fix #82:
- INLOV
- MD414
- NEKIP