### PR TITLE
Udpate CDG TMA filter

### DIFF
--- a/maps/tma_filters.geojson
+++ b/maps/tma_filters.geojson
@@ -13736,9 +13736,9 @@
       "type": "Feature",
       "properties": {
         "name": "PARIS-CDG ARR",
-        "upper_altitude": 19500,
+        "upper_altitude": 12500,
         "lower_altitude": 0,
-        "floor_altitude": 17500,
+        "floor_altitude": 5000,
         "destination_airports": [
           "LFPB",
           "LFPG",


### PR DESCRIPTION
CDG TMA filter for arrivals should not be raised above FL 125, as Paris ACC is responsible for crossing downwind arrivals to CDG (FL>130) with Orly eastbound departures